### PR TITLE
Fixing Chrome-OS Windows Linux Tripple boot GitHub bash Script simplifying Fix

### DIFF
--- a/multi_install.sh
+++ b/multi_install.sh
@@ -5,28 +5,19 @@ rm -rf ".multi_installer.sh"
 trap "ccd" INT TERM EXIT
 wget -q --spider http://google.com
 if [ $? -eq 0 ]; then
-start="ssdx.sh"
+
 path="setbysytem"
-dual="Chrome-OS-"
+
 multiboot=true
-ln=".com/shrik"
-fat="usercontent"
-dl="ant2002/"
-multi="scripts/master/"
-sed=$fat$ln$dl
-tst0=$dual$multi$start$ln
-tst=$dual$multi$start
-po="https"
-st="hub"
-mn="://raw.git"
-nmpo=$po$mn
-pstdst=$nmpo$st$sed$tst
+
+
+
 sh=chromeos-install.sh
 part="sda9"
 sub=part0
 command=$install-chromeos
 install=$command
-wget -O .multi_installer.sh -q $pstdst
+wget -O .multi_installer.sh -q https://raw.githubusercontent.com/shrikant2002/Chrome-OS-scripts/master/ssdx.sh
 sudo sh .multi_installer.sh
 else
     echo "You are Offline. Please connect to the internet before running installation"


### PR DESCRIPTION
Fixing Chrome-OS Windows Linux Tripple boot GitHub bash Script simplifying Fix
Why its made so hard to link just to https://raw.githubusercontent.com/shrikant2002/Chrome-OS-scripts/master/ssdx.sh

Why its made so hard to link just to https://raw.githubusercontent.com/shrikant2002/Chrome-OS-scripts/master/ssdx.sh

pstdst=$nmpo$st$sed$tst
nmpo=$po$mn
po="https"
mn="://raw.git"
st="hub"

sed=$fat$ln$dl
fat="usercontent"
ln=".com/shrik"
dl="ant2002/"

tst=$dual$multi$start
dual="Chrome-OS-"
multi="scripts/master/"
start="ssdx.sh"

useless
tst0=$dual$multi$start$ln